### PR TITLE
fix: OOM in benchmarking of dense and fix memory limit in qk_ar bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,188 @@
+# Multi-GPU Transformer Operation Benchmarking Tool
+
+A comprehensive benchmarking tool for evaluating transformer operations across different NVIDIA GPUs (RTX 3090, A10, H100). This tool measures the performance of key transformer operations including dense matrix multiplication and attention mechanisms across multiple precision formats.
+
+## Features
+
+- Support for multiple NVIDIA GPU architectures:
+  - NVIDIA RTX 3090 (24GB GDDR6X)
+  - NVIDIA A10 (24GB GDDR6)
+  - NVIDIA H100 (80GB HBM3)
+- Multiple precision formats:
+  - FP16 (16-bit floating point)
+  - FP32 (32-bit floating point)
+  - BF16 (16-bit brain floating point)
+  - INT8 (8-bit integer)
+  - FP8 (8-bit floating point, H100 only)
+- Benchmarks three key transformer operations:
+  - Dense matrix multiplication
+  - Query-Key attention initialization
+  - Query-Key attention auto-regressive mode
+- Customizable memory limits
+- Comprehensive CSV and pickle output formats
+- Progress tracking with detailed metrics
+
+## Prerequisites
+
+```bash
+# Required Python packages
+pip install torch numpy pandas tqdm
+```
+
+System requirements:
+- Python 3.7+
+- CUDA-compatible GPU
+- PyTorch with CUDA support
+- Sufficient disk space for output files
+
+## Installation
+
+1. Clone the repository:
+```bash
+git clone https://github.com/yourusername/transformer-benchmarks.git
+cd transformer-benchmarks
+```
+
+2. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Basic Usage
+
+Run benchmarks on a specific GPU with default precision formats:
+```bash
+python benchmark.py --gpu a10     # For NVIDIA A10
+python benchmark.py --gpu 3090    # For RTX 3090
+python benchmark.py --gpu h100    # For H100
+```
+
+Run benchmarks with specific precision formats:
+```bash
+python benchmark.py --gpu h100 --dtype fp16 fp32 bf16   # Multiple precision formats
+python benchmark.py --gpu 3090 --dtype fp16 int8        # Specific formats only
+```
+
+Run benchmarks on all supported GPUs:
+```bash
+python benchmark.py --all
+python benchmark.py --all --dtype fp16 fp32  # All GPUs with specific formats
+```
+
+### Advanced Options
+
+Override default memory limits:
+```bash
+python benchmark.py --gpu a10 --custom-memory 24  # Set custom memory limit in GB
+```
+
+### Command Line Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--gpu` | Specify GPU type (choices: '3090', 'a10', 'h100') |
+| `--dtype` | Specify precision formats to test (choices: 'fp16', 'fp32', 'bf16', 'int8', 'fp8') |
+| `--all` | Run benchmarks on all available GPU types |
+| `--custom-memory` | Override default GPU memory limit (in GB) |
+
+## Output
+
+The tool generates two types of output files in the `data/` directory:
+
+1. CSV files (`transformer-batching-microbenchmarks-{gpu}-multi-dtype-{date}.csv`):
+   - Detailed metrics for each operation
+   - Performance statistics per precision format
+   - Hardware-specific information
+
+2. Pickle files (`{date}-transformer-batching-{gpu}-{dtype}.pkl.gz`):
+   - Raw benchmark data per precision format
+   - Complete measurement results
+   - Compressed format for efficient storage
+
+### Output Metrics
+
+The benchmark results include:
+- Latency measurements
+- Throughput calculations
+- FLOP counts
+- Memory I/O statistics
+- Arithmetic intensity
+- Batch size scaling
+- Sequence length impact
+- Precision format performance comparisons
+
+## Benchmark Configurations
+
+Default configurations tested:
+- Model dimensions: Various combinations of n∈[12,16,32,40,56,72,96] and d∈[64,128]
+- Sequence lengths: [10, 20, 50, 100, 200, 500, 1000, 2000, 4000, 5000]
+- Batch sizes: Range from 1 to 128 with variable increments
+- Precision formats: FP16, FP32, BF16, INT8, FP8 (GPU-dependent)
+
+## Data Analysis
+
+The output CSV files can be analyzed using standard data analysis tools:
+
+```python
+import pandas as pd
+
+# Load benchmark results
+results = pd.read_csv('data/transformer-batching-microbenchmarks-a10-multi-dtype-20241124.csv')
+
+# Basic analysis examples
+throughput_stats = results.groupby(['series', 'dtype'])['throughput'].describe()
+memory_efficiency = results.groupby(['series', 'bs', 'dtype'])['intensity'].mean()
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+
+## License
+
+MIT License (see LICENSE file for details)
+
+## Citation
+
+If you use this benchmark tool in your research, please cite:
+
+```bibtex
+@software{transformer_benchmarks_2024,
+  title={Multi-GPU Transformer Operation Benchmarking Tool},
+  author={Aakash Varma},
+  year={2024},
+  url={https://github.com/yourusername/transformer-benchmarks}
+}
+```
+
+## Troubleshooting
+
+Common issues and solutions:
+
+1. **Out of Memory Errors**
+   - Reduce batch sizes or sequence lengths
+   - Use `--custom-memory` to set appropriate memory limits
+   - Consider using lower precision formats
+
+2. **CUDA Device Not Found**
+   - Ensure CUDA toolkit is properly installed
+   - Check GPU driver version compatibility
+   - Verify PyTorch CUDA support with `torch.cuda.is_available()`
+
+3. **Performance Issues**
+   - Clear GPU cache between runs
+   - Close other GPU-intensive applications
+   - Monitor GPU temperature and throttling
+
+4. **Precision Format Compatibility**
+   - Verify GPU supports requested precision formats
+   - Check PyTorch version supports desired precision
+   - H100-specific features (like FP8) require appropriate hardware
+
+## Support
+
+For bug reports and feature requests, please use the GitHub issue tracker.
+
+For questions and discussions, feel free to reach out to @varmology on X (previously Twitter).

--- a/bench.py
+++ b/bench.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
 
 """
-Transformer Operation Benchmarking Script for A10 GPU
+Transformer Operation Benchmarking Script for Multiple GPUs and DTypes
 
-This script benchmarks various transformer operations on A10 GPU including:
+This script benchmarks various transformer operations on different GPU types including:
+- NVIDIA RTX 3090 (24GB GDDR6X)
+- NVIDIA A10 (24GB GDDR6)
+- NVIDIA H100 (80GB HBM3)
+
+Operations benchmarked:
 1. Dense matrix multiplication
 2. Query-Key attention (initialization phase)
 3. Query-Key attention (auto-regressive phase)
 
-Optimized for A10's features:
-- ~24GB GDDR6 memory
-- Appropriate memory bandwidth
-- FP16 precision support
+Available dtypes:
+- Float16 (fp16)
+- Float32 (fp32)
+- BFloat16 (bf16)
+- Int8 (int8)
+- Float8 (fp8) - H100 only
 """
 
 import os
@@ -24,14 +31,56 @@ import gzip
 from datetime import datetime
 from tqdm.auto import tqdm
 import torch
+import argparse
 
 # Disable gradient computation for benchmarking
 torch.set_grad_enabled(False)
+
+# GPU configurations
+GPU_CONFIGS = {
+    "3090": {
+        "memory": 24e9,  # 24GB GDDR6X
+        "name": "RTX 3090",
+        "supported_dtypes": ["fp16", "fp32", "bf16", "int8"]
+    },
+    "a10": {
+        "memory": 24e9,  # 24GB GDDR6
+        "name": "A10",
+        "supported_dtypes": ["fp16", "fp32", "bf16", "int8"]
+    },
+    "h100": {
+        "memory": 80e9,  # 80GB HBM3
+        "name": "H100",
+        "supported_dtypes": ["fp16", "fp32", "bf16", "int8", "fp8"]
+    }
+}
+DTYPE_MAP = {
+    "fp16": torch.float16,
+    "fp32": torch.float32,
+    "bf16": torch.bfloat16,
+    "int8": torch.int8,
+    "fp8": torch.float8_e4m3fn if hasattr(torch, 'float8_e4m3fn') else None
+}
+DTYPE_SIZES = {
+    "fp16": 2,  # 2 bytes
+    "fp32": 4,  # 4 bytes
+    "bf16": 2,  # 2 bytes
+    "int8": 1,  # 1 byte
+    "fp8": 1    # 1 byte
+}
 
 # Benchmark configurations
 ND_LIST = list(itertools.chain(itertools.product([12, 16, 32], [64]), itertools.product([32, 40, 56, 72, 96], [128])))
 SEQLEN_LIST = [10, 20, 50, 100, 200, 500, 1000, 2000, 4000, 5000]
 BS_LIST = list(itertools.chain(range(1, 8), range(8, 16, 2), range(16, 32, 4), range(32, 64, 8), range(64, 128, 16), [128]))
+
+def get_available_gpu():
+    """
+    Find and return the first available CUDA GPU.
+    """
+    if not torch.cuda.is_available():
+        raise RuntimeError("No CUDA GPUs available")
+    return torch.device(f"cuda:0")
 
 def benchmark(f, *, f_setup=None, min_repeat: int, min_secs: float, tqdm_kwargs: dict | None=None) -> np.ndarray:
     """
@@ -66,10 +115,14 @@ def tail_mean(xs, skip=0.2):
     """Calculate mean of array after skipping initial portion."""
     return xs[int(len(xs) * skip):].mean()
 
-def benchmark_dense(out, nd_list, seqlen_list, bs_list):
+def benchmark_dense(out, nd_list, seqlen_list, bs_list, gpu_config, dtype_name):
     """
-    Benchmark dense matrix multiplication operations using FP16.
+    Benchmark dense matrix multiplication operations using specified precision.
     """
+    device = get_available_gpu()
+    memory_limit = gpu_config["memory"]
+    dtype = DTYPE_MAP[dtype_name]
+    bytes_per_elem = DTYPE_SIZES[dtype_name]
     seqlen_list = [1] + seqlen_list
     total = len(list(itertools.product(nd_list, seqlen_list, bs_list)))
     pbar = tqdm(total=total)
@@ -77,15 +130,14 @@ def benchmark_dense(out, nd_list, seqlen_list, bs_list):
     for (n, d), seqlen in reversed(list(itertools.product(nd_list, seqlen_list))):
         h = n * d
         try:
-            maxbs = max(b for b in bs_list if b*seqlen*h*2 + h*h*2 + b*seqlen*h*2 < 24e9)
+            maxbs = max(b for b in bs_list if (b*seqlen*h + h*h + b*seqlen*h) * bytes_per_elem < memory_limit)
         except ValueError:
             pbar.update(len(bs_list))
             continue
             
-        cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda:0")
-        
-        X = torch.rand((maxbs, seqlen, h), dtype=torch.float16, device="cuda:0")
-        W = torch.rand((h, h), dtype=torch.float16, device="cuda:0")
+        cache = torch.empty(int(256e6 // 4), dtype=torch.int, device=device)
+        X = torch.rand((maxbs, seqlen, h), dtype=dtype, device=device)
+        W = torch.rand((h, h), dtype=dtype, device=device)
             
         torch.cuda.synchronize()
         for bs in reversed(bs_list):
@@ -93,7 +145,7 @@ def benchmark_dense(out, nd_list, seqlen_list, bs_list):
                 pbar.update()
                 continue
                 
-            pbar.set_postfix(n=n, h=h, d=d, seqlen=seqlen, bs=bs)
+            pbar.set_postfix(n=n, h=h, d=d, seqlen=seqlen, bs=bs, dtype=dtype_name)
             def run():
                 torch.matmul(X[:bs], W)
                 torch.cuda.synchronize()
@@ -109,6 +161,7 @@ def benchmark_dense(out, nd_list, seqlen_list, bs_list):
                 "d": d,
                 "seqlen": seqlen,
                 "bs": bs,
+                "dtype": dtype_name,
                 "latency": l
             })
             pbar.update()
@@ -116,28 +169,33 @@ def benchmark_dense(out, nd_list, seqlen_list, bs_list):
         torch.cuda.empty_cache()
     pbar.close()
 
-def benchmark_qk_init(out, nd_list, seqlen_list, bs_list):
+def benchmark_qk_init(out, nd_list, seqlen_list, bs_list, gpu_config, dtype_name):
     """
     Benchmark Query-Key attention initialization.
-    Optimized for A10's memory capacity.
     """
+    device = get_available_gpu()
+    memory_limit = gpu_config["memory"]
+    dtype = DTYPE_MAP[dtype_name]
+    bytes_per_elem = DTYPE_SIZES[dtype_name]
     total = len(list(itertools.product(nd_list, seqlen_list, bs_list)))
     pbar = tqdm(total=total)
+    
     for (n, d), seqlen in reversed(list(itertools.product(nd_list, seqlen_list))):
         h = n * d
         try:
-            # Adjusted memory limit for A10 (~24GB)
-            maxbs = max(b for b in bs_list if b*n*seqlen*d*2*2+b*n*seqlen**2*2 < 24e9)
+            # maxbs = max(b for b in bs_list if b*n*seqlen*d*2*2+b*n*seqlen**2*2 < memory_limit)
+            maxbs = max(b for b in bs_list if (b*n*seqlen*d*2 + b*n*seqlen**2) * bytes_per_elem < memory_limit)
         except ValueError:
             pbar.update(len(bs_list))
             continue
             
-        cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda:0")
-        Qmax = torch.rand((maxbs, n, seqlen, d), dtype=torch.float16, device="cuda:0")
-        Kmax = torch.rand((maxbs, n, seqlen, d), dtype=torch.float16, device="cuda:0")
+        cache = torch.empty(int(256e6 // 4), dtype=torch.int, device=device)
+        Qmax = torch.rand((maxbs, n, seqlen, d), dtype=dtype, device=device)
+        Kmax = torch.rand((maxbs, n, seqlen, d), dtype=dtype, device=device)
+            
         torch.cuda.synchronize()
         for bs in reversed(bs_list):
-            pbar.set_postfix(n=n, h=h, d=d, seqlen=seqlen, bs=bs)
+            pbar.set_postfix(n=n, h=h, d=d, seqlen=seqlen, bs=bs, dtype=dtype_name)
             if bs > maxbs:
                 pbar.update()
                 continue
@@ -157,6 +215,7 @@ def benchmark_qk_init(out, nd_list, seqlen_list, bs_list):
                 "d": d,
                 "seqlen": seqlen,
                 "bs": bs,
+                "dtype": dtype_name,
                 "latency": l
             })
             pbar.update()
@@ -164,32 +223,34 @@ def benchmark_qk_init(out, nd_list, seqlen_list, bs_list):
         torch.cuda.empty_cache()
     pbar.close()
 
-def benchmark_qk_ar(out, nd_list, seqlen_list, bs_list):
+def benchmark_qk_ar(out, nd_list, seqlen_list, bs_list, gpu_config, dtype_name):
     """
     Benchmark Query-Key attention in auto-regressive mode.
-    Optimized for A10 capabilities.
     """
+    device = get_available_gpu()
+    memory_limit = gpu_config["memory"]
+    dtype = DTYPE_MAP[dtype_name]
+    bytes_per_elem = DTYPE_SIZES[dtype_name]
     total = len(list(itertools.product(nd_list, seqlen_list, bs_list)))
     pbar = tqdm(total=total)
+    
     for (n, d), seqlen in reversed(list(itertools.product(nd_list, seqlen_list))):
         h = n * d
         try:
-            # Adjusted memory limit for A10
-            maxbs = max(b for b in bs_list if b*n*(1+seqlen)*d*2+b*n*seqlen*2 < 24e9)
+            # maxbs = max(b for b in bs_list if b*n*(1+seqlen)*d*2+b*n*seqlen*2 < memory_limit)
+            maxbs = max(b for b in bs_list if (b*n*(1+seqlen)*d + b*n*seqlen) * bytes_per_elem < memory_limit)
         except ValueError:
             pbar.update(len(bs_list))
             continue
             
-        cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda:0")
-        
-        # Use FP16 for all computations
-        Qmax = torch.rand((maxbs, n, 1, d), dtype=torch.float16, device="cuda:0")
-        Kmax = torch.rand((maxbs, n, seqlen, d), dtype=torch.float16, device="cuda:0")
+        cache = torch.empty(int(256e6 // 4), dtype=torch.int, device=device)
+        Qmax = torch.rand((maxbs, n, 1, d), dtype=dtype, device=device)
+        Kmax = torch.rand((maxbs, n, seqlen, d), dtype=dtype, device=device)
             
         torch.cuda.synchronize()
         
         for bs in reversed(bs_list):
-            pbar.set_postfix(n=n, h=h, d=d, seqlen=seqlen, bs=bs)
+            pbar.set_postfix(n=n, h=h, d=d, seqlen=seqlen, bs=bs, dtype=dtype_name)
             if bs > maxbs:
                 pbar.update()
                 continue
@@ -213,6 +274,7 @@ def benchmark_qk_ar(out, nd_list, seqlen_list, bs_list):
                 "d": d,
                 "seqlen": seqlen,
                 "bs": bs,
+                "dtype": dtype_name,
                 "latency": l
             })
             pbar.update()
@@ -220,90 +282,148 @@ def benchmark_qk_ar(out, nd_list, seqlen_list, bs_list):
         torch.cuda.empty_cache()
     pbar.close()
 
-def process_results(data):
+def process_results(data, gpu_config):
     """Process benchmark results and save as CSV."""
-    df_dense = (
-        pd.DataFrame.from_dict(data["dense"])
-        .assign(h=lambda x: x["n"] * x["d"])
-        .assign(flop=lambda x: (x["bs"] * x["seqlen"] * x["h"]**2) * 2)
-        .assign(io=lambda x: (x["bs"]*x["seqlen"]*x["h"]*2 + x["h"]**2) * 2)
-        .assign(intensity=lambda x: x["flop"] / x["io"])
-        .assign(throughput=lambda x: x["bs"]*x["seqlen"] / x["latency"])
-        .assign(series="dense")
-    )
-    df_qk_init = (
-        pd.DataFrame.from_dict(data["qk_init"])
-        .assign(h=lambda x: x["n"] * x["d"])
-        .assign(flop=lambda x: (x["bs"]*x["n"]*x["d"]*x["seqlen"]**2) * 2)
-        .assign(io=lambda x: (x["bs"]*x["n"]*(x["seqlen"]*x["d"]*2 + x["seqlen"]**2)) * 2)
-        .assign(intensity=lambda x: x["flop"] / x["io"])
-        .assign(throughput=lambda x: x["bs"]*x["seqlen"] / x["latency"])
-        .assign(series="qk_init")
-    )
-    df_qk_ar = (
-        pd.DataFrame.from_dict(data["qk_ar"])
-        .assign(h=lambda x: x["n"] * x["d"])
-        .assign(flop=lambda x: (x["bs"]*x["n"]*x["d"]*x["seqlen"]) * 2)
-        .assign(io=lambda x: (x["bs"]*x["n"]*(x["d"] + x["seqlen"]*x["d"] + x["seqlen"])) * 2)
-        .assign(intensity=lambda x: x["flop"] / x["io"])
-        .assign(throughput=lambda x: x["bs"] / x["latency"])
-        .assign(series="qk_ar")
-    )
-    
-    # Add A10-specific metrics
-    for df in [df_dense, df_qk_init, df_qk_ar]:
-        df['gpu'] = 'A10'
-        df['precision'] = 'fp16'
+    results = []
+    for dtype_name in data:
+        df_dense = (
+            pd.DataFrame.from_dict(data[dtype_name]["dense"])
+            .assign(h=lambda x: x["n"] * x["d"])
+            .assign(flop=lambda x: (x["bs"] * x["seqlen"] * x["h"]**2) * 2)
+            .assign(io=lambda x: (x["bs"]*x["seqlen"]*x["h"]*2 + x["h"]**2) * 2)
+            .assign(intensity=lambda x: x["flop"] / x["io"])
+            .assign(throughput=lambda x: x["bs"]*x["seqlen"] / x["latency"])
+            .assign(series="dense")
+            .assign(dtype=dtype_name)
+        )
+        
+        df_qk_init = (
+            pd.DataFrame.from_dict(data[dtype_name]["qk_init"])
+            .assign(h=lambda x: x["n"] * x["d"])
+            .assign(flop=lambda x: (x["bs"]*x["n"]*x["d"]*x["seqlen"]**2) * 2)
+            .assign(io=lambda x: (x["bs"]*x["n"]*(x["seqlen"]*x["d"]*2 + x["seqlen"]**2)) * 2)
+            .assign(intensity=lambda x: x["flop"] / x["io"])
+            .assign(throughput=lambda x: x["bs"]*x["seqlen"] / x["latency"])
+            .assign(series="qk_init")
+            .assign(dtype=dtype_name)
+        )
+        
+        df_qk_ar = (
+            pd.DataFrame.from_dict(data[dtype_name]["qk_ar"])
+            .assign(h=lambda x: x["n"] * x["d"])
+            .assign(flop=lambda x: (x["bs"]*x["n"]*x["d"]*x["seqlen"]) * 2)
+            .assign(io=lambda x: (x["bs"]*x["n"]*(x["d"] + x["seqlen"]*x["d"] + x["seqlen"])) * 2)
+            .assign(intensity=lambda x: x["flop"] / x["io"])
+            .assign(throughput=lambda x: x["bs"] / x["latency"])
+            .assign(series="qk_ar")
+            .assign(dtype=dtype_name)
+        )
+        
+        results.extend([df_dense, df_qk_init, df_qk_ar])
 
     # Combine and save all results
     timestamp = datetime.now().strftime("%Y%m%d")
-    pd.concat([df_dense, df_qk_init, df_qk_ar]).to_csv(
-        f"data/transformer-batching-microbenchmarks-a10-fp16-{timestamp}.csv", 
+    gpu_name = gpu_config["name"].lower().replace(" ", "-")
+    pd.concat(results).to_csv(
+        f"data/transformer-batching-microbenchmarks-{gpu_name}-multi-dtype-{timestamp}.csv", 
         index=False
     )
 
-def main():
-    # Run benchmarks
-    data = {}
+def main(gpu_type, dtypes=None):
+    gpu_config = GPU_CONFIGS[gpu_type.lower()]
     
-    print("Running Query-Key initialization benchmarks...")
-    db = []
-    benchmark_qk_init(db, ND_LIST, SEQLEN_LIST, BS_LIST)
-    data["qk_init"] = db
+    # Use all supported dtypes if none specified
+    if dtypes is None:
+        dtypes = gpu_config["supported_dtypes"]
+    
+    # Run benchmarks
+    data = {dtype: {} for dtype in dtypes}
+    
+    print(f"\nRunning benchmarks on {gpu_config['name']}...")
+    print(f"Memory limit: {gpu_config['memory']/1e9:.1f}GB")
+    print(f"Testing dtypes: {', '.join(dtypes)}")
+    
+    for dtype in dtypes:
+        print(f"\nRunning benchmarks for {dtype}...")
+        
+        print("\nRunning Query-Key initialization benchmarks...")
+        db = []
+        benchmark_qk_init(db, ND_LIST, SEQLEN_LIST, BS_LIST, gpu_config, dtype)
+        data[dtype]["qk_init"] = db
 
-    print("Running Query-Key auto-regressive benchmarks...")
-    db = []
-    benchmark_qk_ar(db, ND_LIST, SEQLEN_LIST, BS_LIST)
-    data["qk_ar"] = db
+        print("\nRunning Query-Key auto-regressive benchmarks...")
+        db = []
+        benchmark_qk_ar(db, ND_LIST, SEQLEN_LIST, BS_LIST, gpu_config, dtype)
+        data[dtype]["qk_ar"] = db
 
-    print("Running dense operation benchmarks...")
-    db = []
-    benchmark_dense(db, ND_LIST, SEQLEN_LIST, BS_LIST)
-    data["dense"] = db
+        print("\nRunning dense operation benchmarks...")
+        db = []
+        benchmark_dense(db, ND_LIST, SEQLEN_LIST, BS_LIST, gpu_config, dtype)
+        data[dtype]["dense"] = db
 
-    # Save benchmark results
-    timestamp = datetime.now().strftime("%Y%m%d")
-    with gzip.open(f"data/{timestamp}-transformer-batching-a10-fp16.pkl.gz", "wb") as f:
-        pickle.dump(data, f)
+        # Save benchmark results
+        timestamp = datetime.now().strftime("%Y%m%d")
+        gpu_name = gpu_config["name"].lower().replace(" ", "-")
+        with gzip.open(f"data/{timestamp}-transformer-batching-{gpu_name}-{dtype}.pkl.gz", "wb") as f:
+            pickle.dump(data[dtype], f)
 
     # Process and save results as CSV
-    process_results(data)
+    process_results(data, gpu_config)
 
 if __name__ == "__main__":
+    # Set up argument parser
+    parser = argparse.ArgumentParser(description='Transformer operation benchmarking across multiple GPU types')
+    parser.add_argument('--gpu', type=str, choices=['3090', 'a10', 'h100'], 
+                      help='GPU type to benchmark (3090, a10, or h100)')
+    parser.add_argument('--dtype', type=str, nargs='+',
+                      choices=['fp16', 'fp32', 'bf16', 'int8', 'fp8'],
+                      help='Data types to benchmark')
+    parser.add_argument('--all', action='store_true', 
+                      help='Run benchmarks on all available GPU types')
+    parser.add_argument('--custom-memory', type=float,
+                      help='Override default GPU memory limit in GB (optional)')
+    args = parser.parse_args()
+
     # Create data directory if it doesn't exist
     os.makedirs("data", exist_ok=True)
     
-    # Print configuration and A10-specific information
-    print("Starting transformer benchmarking on A10 GPU...")
-    print("\nA10 Specific Features:")
-    print("- Using FP16 precision for all operations")
-    print("- Memory capacity: ~24GB GDDR6")
-    print("- Optimized for A10 memory bandwidth")
-    
+    # Print available GPU information
+    if torch.cuda.is_available():
+        print(f"Available GPU: {torch.cuda.get_device_name(0)}")
+        print(f"Total GPU memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f}GB")
+    else:
+        raise RuntimeError("No CUDA GPU available for benchmarking")
+
+    # Handle custom memory limit
+    if args.custom_memory:
+        for gpu in GPU_CONFIGS:
+            GPU_CONFIGS[gpu]["memory"] = args.custom_memory * 1e9
+        print(f"\nUsing custom memory limit: {args.custom_memory}GB")
+
+    # Print configuration
     print("\nBenchmarking configurations:")
     print("- Model configurations:", ND_LIST)
     print("- Sequence lengths:", SEQLEN_LIST)
     print("- Batch sizes:", BS_LIST)
-    
-    # Run main benchmark suite
-    main()
+
+    if args.all:
+        # Run benchmarks for all GPU types
+        for gpu_type in GPU_CONFIGS:
+            try:
+                print(f"\n{'='*50}")
+                print(f"Starting benchmarks for {GPU_CONFIGS[gpu_type]['name']}")
+                print(f"{'='*50}")
+                main(gpu_type, args.dtype)
+            except Exception as e:
+                print(f"Error running benchmarks for {gpu_type}: {str(e)}")
+                continue
+    elif args.gpu:
+        # Run benchmarks for specified GPU type
+        if args.gpu.lower() not in GPU_CONFIGS:
+            print(f"Error: Unsupported GPU type '{args.gpu}'")
+            print(f"Supported GPUs: {list(GPU_CONFIGS.keys())}")
+            exit(1)
+        main(args.gpu, args.dtype)
+    else:
+        parser.print_help()
+        exit(1)


### PR DESCRIPTION
# Fix GPU memory limit calculations for A10 benchmarks

## Summary
This PR addresses memory calculation issues in the transformer benchmark suite for A10 GPUs.

## Changes

### Dense Operation Memory Check
- Added missing output tensor memory calculation in `benchmark_dense`
- Memory formula updated to: `b*seqlen*h*2 + h*h*2 + b*seqlen*h*2 < 24e9`
- Accounts for:
  - Input tensor
  - Weight matrix
  - Output tensor sizes

### Auto-regressive QK Attention Memory Limit
- Fixed incorrect memory limit in `benchmark_qk_ar`
- Changed from 48GB to 24GB to match A10 specifications
- Formula remains: `b*n*(1+seqlen)*d*2+b*n*seqlen*2 < 24e9`

## Impact
- More accurate memory usage calculation for dense operations
- Prevents potential OOM errors by properly accounting for output tensors
- Aligns memory limits with actual A10 GPU specifications (24GB)
- Ensures consistent memory constraints across all benchmark functions

## Testing
Please verify these changes with various model sizes on A10 hardware to ensure no OOM errors occur.